### PR TITLE
fix(entity-store): add missing sorting to search

### DIFF
--- a/src/entity/DynamicLoadingStore.test.ts
+++ b/src/entity/DynamicLoadingStore.test.ts
@@ -151,4 +151,33 @@ describe('DynamicLoadingStore', function () {
 
         forkJoin([first, second].map((p) => p.toPromise())).subscribe(() => done());
     });
+
+    it('should load values in a sorted manner', function () {
+        const store = createDynamicLoadingStore<TestClass, number, number[]>({
+            selectIdFunction: (entity) => entity.id,
+            loadFunction: (id) => of(testValues.get(id) || {id: id, value: 'id:' + id}),
+            searchFunction: () => true,
+            searchLoadFunction: (searchParams) => of(searchParams),
+            sortFunction: (entity1, entity2) => {
+                if (entity1.id > entity2.id) {
+                    return 1;
+                } else if (entity2.id > entity1.id) {
+                    return -1;
+                } else {
+                    return 0;
+                }
+            },
+        });
+
+        const testObjects = store.search([1, 2, 5, 4, 3]);
+        console.log(testObjects);
+        expect(testObjects).toHaveLength(5);
+        expect(testObjects).toStrictEqual([
+            {id: 1, value: 'one'},
+            {id: 2, value: 'two'},
+            {id: 3, value: 'three'},
+            {id: 4, value: 'four'},
+            {id: 5, value: 'five'},
+        ]);
+    });
 });

--- a/src/entity/EntityHandler.ts
+++ b/src/entity/EntityHandler.ts
@@ -35,7 +35,7 @@ export class EntityHandler<entity, id extends idType = number> {
     private ids: Set<id> = new Set();
 
     private readonly selectIdFunction: selectIdFunctionType<entity, id>;
-    private readonly sortFunction: sortFunctionType<entity>;
+    public readonly sortFunction: sortFunctionType<entity>;
 
     constructor(selectIdFunction: selectIdFunctionType<entity, id>, sortFunction?: sortFunctionType<entity>) {
         this.selectIdFunction = selectIdFunction;

--- a/src/entity/EntityStore.ts
+++ b/src/entity/EntityStore.ts
@@ -137,12 +137,12 @@ export class EntityStore<entity, id extends idType = number, searchType = string
     // todo: needs proper subscriptions (is this possible?)
     @autoSubscribeWithKey(triggerEntityKey)
     public search(searchParam: searchType): ReadonlyArray<entity> {
-        return (
-            this.searchIds(searchParam)
-                .map(this.getOne.bind(this))
-                // no !entity, or else we would not allow 0 or null as return value
-                .filter((entity) => entity !== undefined) as ReadonlyArray<entity>
-        );
+        const entities = this.searchIds(searchParam)
+            .map(this.getOne.bind(this))
+            // no !entity, or else we would not allow 0 or null as return value
+            .filter((entity) => entity !== undefined) as ReadonlyArray<entity>;
+        const sortedEntities = entities.slice().sort(this.entityHandler.sortFunction);
+        return sortedEntities;
     }
 
     @autoSubscribeWithKey(triggerEntityKey)


### PR DESCRIPTION
I noticed that the sorting function is ignored for the `search` method. This PR suggests to add support for it.